### PR TITLE
feat: docker-entrypoint.sh 생성

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,14 @@ RUN pip install --no-cache-dir -r requirements.txt
 # 앱 파일 복사
 COPY . /app
 
+# docker-entrypoint.sh 추가
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
 # 포트 8501 열기
 EXPOSE 8501
 
+# 엔트리포인트 설정
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 # Streamlit 앱 실행
-CMD ["streamlit", "run", "app.py"]
+# CMD ["streamlit", "run", "app.py"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# 필요한 환경 변수가 설정되었는지 확인
+if [ -z "$AUTH0_APP_URL" ]; then
+    echo "AUTH0_APP_URL is not set. Defaulting to 'http://localhost:3000'."
+    export AUTH0_APP_URL='http://localhost:3000'
+fi
+
+# 필요한 서비스가 실행될 때까지 대기
+echo "Waiting for dependent services to be up..."
+sleep 10  # 예시로 10초 대기
+
+# Streamlit 앱 실행
+exec streamlit run app.py "$@"


### PR DESCRIPTION
eks cluster 내에서 webservice를 배포할 때 환경 변수로 AUTH0_APP_URL를 설정함 이때 nginx ingress의 ip와 port를 조회해 AUTH0_APP_URL를 설정하고 docker-entrypoint에서 이 값을 가져와 pod내 환경변수로 배포하기 위함